### PR TITLE
Fixes typo in "stay connected" buddycloud url

### DIFF
--- a/theme/templates/index.html
+++ b/theme/templates/index.html
@@ -75,7 +75,7 @@
         <h3>Stay connected</h3>
         <div class="contact">
           <a href="https://twitter.com/buddycloud" class="twitter">Twitter</a> <a href="http://blog.buddycloud.com" class="blog">Blog</a> <a
-            href="https://github.com/buddycloud" class="github">Github</a> <a href="https://demo.buddycloud.org/team@topics.buddycloud.com" class="buddycloud">buddyloud</a>
+            href="https://github.com/buddycloud" class="github">Github</a> <a href="https://demo.buddycloud.org/team@topics.buddycloud.org" class="buddycloud">buddyloud</a>
           <br>
         </div>
       </div>


### PR DESCRIPTION
In the "Stay Connected" section of http://buddycloud.com/  the (b) icon links to:
![sad panda](https://www.evernote.com/shard/s61/sh/346228b9-616d-4a58-a857-e2343e4e859e/75f5876d259ac4baa814ca9c7f3e7be7/res/622f6cb2-5300-418c-ac9f-67129b8fb10d/screenshot.png?resizeSmall&width=832)

I believe this PR corrects the issue.

![happy unicorn](https://www.evernote.com/shard/s61/sh/7c7f272e-36c2-4a70-9518-b35ddf716043/35306b2fb21863befcdaeddb2462cba1/res/415e3ce6-a28c-44f8-976a-33d0ae9baa66/screenshot.png?resizeSmall&width=832)
